### PR TITLE
Add LibFlatArray-based implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+
+find_package(libflatarray)
+include_directories(${libflatarray_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -march=native -DHAVE__M128")
+set(CMAKE_BUILD_TYPE "Release")
+
+add_executable(soa_block.test soa_block.test.cpp)
+add_executable(soa_compare.benchmark soa_compare.benchmark.cpp)
+add_executable(udt.test udt.test.cpp)
+add_executable(vec_offsets.test vec_offsets.test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
 
 find_package(libflatarray)
 include_directories(${libflatarray_INCLUDE_DIRS})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -march=native -DHAVE__M128")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -march=native -DHAVE__M128 -DHAVE_LIBFLATARRAY")
 set(CMAKE_BUILD_TYPE "Release")
 
 add_executable(soa_block.test soa_block.test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
 
 find_package(libflatarray)
 include_directories(${libflatarray_INCLUDE_DIRS})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -march=native -DHAVE__M128 -DHAVE_LIBFLATARRAY")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -march=native -DHAVE__M128 -DHAVE_LIBFLATARRAY -DUSE_SMALL_PARTICLE_COUNT")
 set(CMAKE_BUILD_TYPE "Release")
 
 add_executable(soa_block.test soa_block.test.cpp)

--- a/soa_compare.benchmark.cpp
+++ b/soa_compare.benchmark.cpp
@@ -152,14 +152,14 @@ uniform_real_distribution<float> edist( 10.f, 1000.f );
 
 constexpr float gravity = -9.8f;
 constexpr float dt = 1.0f;
-constexpr size_t particle_count =
 //#define USE_SMALL_PARTICLE_COUNT
 #ifdef USE_SMALL_PARTICLE_COUNT
-  1000
+constexpr size_t particle_count = 1024;
+constexpr size_t frames = 2000000;
 #else
-  15625 * 64
+constexpr size_t particle_count = 15625 * 64;
+constexpr size_t frames = 1000;
 #endif
-  ;
 
 struct aos_emitter_t {
     vector<particle_t> particles;
@@ -680,8 +680,6 @@ struct soa_emitter_sse_opt_t {
 template< typename emitter_t >
 chrono::duration<double> run_test() {
     using clock_t = chrono::high_resolution_clock;
-
-    constexpr size_t frames = 1000;
 
     const auto seed_val = mt19937::default_seed;
     mt19937 rng( seed_val );

--- a/soa_compare.benchmark.cpp
+++ b/soa_compare.benchmark.cpp
@@ -6,19 +6,19 @@
 //      http://codepad.org/eol6auRN
 //RESULT:
 /*
-/tmp/build/clangxx3_8_pkg/clang/struct_of_arrays/work/soa_compare.benchmark.exe 
+/tmp/build/clangxx3_8_pkg/clang/struct_of_arrays/work/soa_compare.benchmark.exe
 particle_count=1,000,000
 minimum duration=5.18095
 
 comparitive performance table:
 
-method   rel_duration   
-________ ______________ 
-Block    1             
-StdArray 1.00159       
-Flat     1.00874       
-SoA      1.0325        
-AoS      1.39591       
+method   rel_duration
+________ ______________
+Block    1
+StdArray 1.00159
+Flat     1.00874
+SoA      1.0325
+AoS      1.39591
 
 Compilation finished at Mon Oct 24 08:26:48
  */
@@ -144,10 +144,10 @@ soa_method_enum
   , StdArray
   , Block
   , LFA
-#ifdef HAVE__M128  
+#ifdef HAVE__M128
   , SSE
   , SSE_opt
-#endif  
+#endif
   , soa_method_last
   };
   template
@@ -158,7 +158,7 @@ struct emitter_t
   template<>
 struct emitter_t<AoS> {
     static constexpr char const*name(){return "AoS";}
-    
+
     vector<particle_t> particles;
 
     void generate( size_t n, mt19937 & rng ) {
@@ -257,7 +257,7 @@ struct emitter_t<Flat> {
 
     char * data;
     size_t capacity;
-    
+
     ~emitter_t() {
         free();
     }
@@ -341,7 +341,7 @@ using soa_array = array<T, particle_count>;
   template<>
 struct emitter_t<StdArray> {
     static constexpr char const*name(){return "StdArray";}
-    
+
     typedef tuple<
         soa_array<float3>,
         soa_array<float3>,
@@ -350,7 +350,7 @@ struct emitter_t<StdArray> {
         soa_array<float4>,
         soa_array<float>,
         soa_array<char> > data_t;
-        
+
     unique_ptr<data_t> data;
 
     void generate( size_t n, mt19937 & rng ) {
@@ -406,7 +406,7 @@ struct emitter_t<Block>
         char> data_t;
 
     data_t data;
-    
+
     emitter_t()
       : data(particle_count)
       {}
@@ -624,7 +624,7 @@ struct sse_t<SSE> {
   template<>
 struct emitter_t<SSE_opt> {
     static constexpr char const*name(){return "SSE_opt";}
-    
+
     sse_vector<float> position_x;
     sse_vector<float> position_y;
     sse_vector<float> position_z;
@@ -714,7 +714,7 @@ dur_t=double;
 run_result_t=std::pair<char const*,dur_t>;
   template< typename emitter_t >
   run_result_t
-run_test() 
+run_test()
   {
     using clock_t = chrono::high_resolution_clock;
 
@@ -783,7 +783,7 @@ run_tests
          <<"\n";
      }
   }
-int main() 
+int main()
   {
     cout.imbue(std::locale(""));//for thousands separator.
     cout << "particle_count="<< particle_count<< std::endl;

--- a/soa_compare.benchmark.cpp
+++ b/soa_compare.benchmark.cpp
@@ -36,9 +36,9 @@ SoA block in 0.0805211 seconds
 //    RESULT:
 //      Now, soa_block method fastest(by small amount):
 /*
-/home/evansl/dwnlds/llvm/3.8/prebuilt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++ -c -O2 -stdlib=libc++  -std=c++14 -ftemplate-backtrace-limit=0 -fdiagnostics-show-template-tree -fno-elide-type -fmacro-backtrace-limit=0       -DTYPE_AT_IMPL=0   -ftemplate-depth=200  codepad.eol6auRN.cpp -MMD -o /tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.o 
+/home/evansl/dwnlds/llvm/3.8/prebuilt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++ -c -O2 -stdlib=libc++  -std=c++14 -ftemplate-backtrace-limit=0 -fdiagnostics-show-template-tree -fno-elide-type -fmacro-backtrace-limit=0       -DTYPE_AT_IMPL=0   -ftemplate-depth=200  codepad.eol6auRN.cpp -MMD -o /tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.o
 /home/evansl/dwnlds/llvm/3.8/prebuilt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/clang++ -stdlib=libc++    /tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.o   -o /tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.exe
-/tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.exe 
+/tmp/build/gcc4_9_0/clang/struct_of_arrays/work/codepad.eol6auRN.exe
 particle_count=1,000,000
 AoS in 7.18701 seconds
 SoA in 5.38178 seconds
@@ -70,7 +70,7 @@ using boost::alignment::aligned_allocator;
   using goon::bit_vector;
 #else
   using bit_vector = std::vector<bool>;
-#endif  
+#endif
 
 struct float2 {
     float x, y;
@@ -121,7 +121,7 @@ uniform_real_distribution<float> edist( 10.f, 1000.f );
 
 constexpr float gravity = -9.8f;
 constexpr float dt = 1.0f;
-constexpr size_t particle_count = 
+constexpr size_t particle_count =
 //#define USE_SMALL_PARTICLE_COUNT
 #ifdef USE_SMALL_PARTICLE_COUNT
   1000
@@ -224,7 +224,7 @@ struct soa_emitter_flat_t {
 
     char * data;
     size_t capacity;
-    
+
     ~soa_emitter_flat_t() {
         free();
     }
@@ -245,7 +245,7 @@ struct soa_emitter_flat_t {
     void free() {
         delete data;
     }
-    
+
     float3* get_position()      { return reinterpret_cast<float3*>(data); }
     float3* get_velocity()      { return reinterpret_cast<float3*>(data + capacity * offsetof(particle_t, velocity)); }
     float3* get_acceleration()  { return reinterpret_cast<float3*>(data + capacity * offsetof(particle_t, acceleration)); }
@@ -302,7 +302,7 @@ struct soa_emitter_flat_t {
         energy,
         alive
     };
-    
+
 template< typename T >
 using soa_array = array<T, particle_count>;
 
@@ -352,9 +352,9 @@ struct soa_emitter_static_t {
 };
 
 #include "soa_block.hpp"
-struct soa_emitter_block_t 
+struct soa_emitter_block_t
 /**@brief
- *  Pretty much cut&past from above 
+ *  Pretty much cut&past from above
  *    soa_emitter_static_t
  *  but use soa_block instead of soa_array.
  */
@@ -371,12 +371,12 @@ struct soa_emitter_block_t
     data_t data;
     typedef decltype(data.begin_all()) begins_t;
     begins_t const begins_v;
-    
+
     soa_emitter_block_t()
       : data(particle_count)
       , begins_v(data.begin_all())
       {}
-    
+
     void generate( size_t n, mt19937 & rng ) {
         for ( size_t i = 0; i < n; ++i ) {
             get<position>(begins_v)[i] = float3{ pdist( rng ), pdist( rng ), pdist( rng ) };
@@ -619,6 +619,6 @@ int main() {
     cout << "SoA SSE in " << soa_sse_duration.count() << " seconds" << std::endl;
     cout << "SoA SSE opt in " << soa_sse_opt_duration.count() << " seconds" << std::endl;
   #endif
-#endif  
+#endif
     return 0;
 }


### PR DESCRIPTION
The main contribution of this PR is to implement the kernel with LibFlatArray's SoA containers and vectorization expression templates.

I've also added some minor improvements (e.g. setting the number of frames depending on the number of particles, remove trailing whitespace, a CMake script for compilation).

Open issue: If I enable SSE then my compiler complains about sse_t being unknown. Did you perhaps forget to add that code? I didn't see any definition of that class, just a specialization.

Cheers!
-Andreas
